### PR TITLE
Disabled incremental linking by default.

### DIFF
--- a/CoApp.Powershell/etc/vcxproj.inc
+++ b/CoApp.Powershell/etc/vcxproj.inc
@@ -14,6 +14,7 @@
     <ConfigurationType>$(OverrideConfigurationType)</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup>
+    <LinkIncremental>false</LinkIncremental>
     <LibName Condition="'|$(LibName)|'=='||'">$(ProjectName)</LibName>
     <UseDebugLibraries Condition="$(Configuration.ToLower().IndexOf('debug'))!=-1">true</UseDebugLibraries>
     <UseDebugLibraries Condition="$(Configuration.ToLower().IndexOf('debug'))==-1">false</UseDebugLibraries>


### PR DESCRIPTION
Having it enabled by default doesn't appear to provide any benefit, and it inflates the size of output locations.
May be re-enabled by individual projects as needed.
