### PR TITLE
Custom tasks

### DIFF
--- a/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
@@ -32,10 +32,27 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
     using Platform;
     using Powershell.Core;
     using Utility;
+    using ClrPlus.Core.Collections;
 
     internal enum PackageRole {
         @default,
         overlay,
+    }
+
+    internal class CustomTaskInfo
+    {
+        public string TaskName;
+        public string TaskDLLPath;
+
+        public IEnumerable<ToRoute> MemberRoutes
+        {
+            get
+            {
+                string Name = "name";
+                yield return "name".MapTo(() => TaskName, v => TaskName = (string) v);
+                yield return "DLL".MapTo(() => TaskDLLPath, v => TaskDLLPath = (string) v);
+            }
+        }
     }
 
     internal class NugetPackage : IProjectOwner {
@@ -70,6 +87,8 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
 
         internal Lazy<ProjectPlus> Props;
         internal Lazy<ProjectPlus> Targets;
+
+        internal List<CustomTaskInfo> CustomTasks;
 
         public string ProjectName {
             get {
@@ -111,6 +130,7 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
            
             Props = new Lazy<ProjectPlus>(() => new ProjectPlus(this, "{0}.props".format(_pkgName)));
             Targets = new Lazy<ProjectPlus>(() => new ProjectPlus(this, "{0}.targets".format(_pkgName)));
+            CustomTasks = new List<CustomTaskInfo>();
 
             _nuSpec.metadata.id = "Package";
             _nuSpec.metadata.version = "1.0.0";

--- a/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
@@ -360,6 +360,14 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
                     usingTask.Condition = "'$(DesignTimeBuild)' != 'true' AND ('$(NugetMsBuildExtensionLoaded)' == '' OR '$(NugetMsBuildExtensionLoaded)' == 'false')";
                 }
 
+                // Register any custom tasks requested.
+                // TODO: remove the Where clause when we figure out how to have a clean set of tasks here.
+                foreach (var t in CustomTasks.Where(tinfo => tinfo.TaskName != null))
+                {
+                    var usingTask = Targets.Value.Xml.AddUsingTask(t.TaskName, string.Format("$(NuGet-NativeExtensionPath)\\{0}", Path.GetFileName(t.TaskDLLPath)), null);
+                    usingTask.Condition = "'$(DesignTimeBuild)' != 'true' AND ('$(NugetMsBuildExtensionLoaded)' == '' OR '$(NugetMsBuildExtensionLoaded)' == 'false')";
+                }
+
                 
                 // 'declare' the  property in props
                 var pg = Props.Value.Xml.AddPropertyGroup();

--- a/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/NugetPackage.cs
@@ -48,7 +48,6 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
         {
             get
             {
-                string Name = "name";
                 yield return "name".MapTo(() => TaskName, v => TaskName = (string) v);
                 yield return "DLL".MapTo(() => TaskDLLPath, v => TaskDLLPath = (string) v);
             }

--- a/clrplus/Scripting.MsBuild/Packaging/PackageScript.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/PackageScript.cs
@@ -186,11 +186,18 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
             
             // always need a targets
             nugetView.AddChildRoute("targets".MapTo(NugetPackage.Targets.Value/*, GetTargetsProject("default").ProjectRoutes() */));
+
+            // Keep track of any user custom tasks that should be defined.
+            // TODO: the CustomTasks.Add is wrong below. It gets called three times, rather than just once for a single input.
+            //       But I do not understand how to link it to the CUustomTask list above there.
+            nugetView.AddChildRoute(
+                "customtasks".MapTo(NugetPackage.CustomTasks, 
+                new[] { 
+                    "task".MapTo(() => { var nv = new CustomTaskInfo(); NugetPackage.CustomTasks.Add(nv); return nv; })
+                }));
+
             // other variants/frameworks
-
         }
-
-
 
         public void Initialize(PackageTypes packageTypes = PackageTypes.All) {
             if (_initialized) {

--- a/clrplus/Scripting.MsBuild/Packaging/PackageScript.cs
+++ b/clrplus/Scripting.MsBuild/Packaging/PackageScript.cs
@@ -190,6 +190,8 @@ namespace ClrPlus.Scripting.MsBuild.Packaging {
             // Keep track of any user custom tasks that should be defined.
             // TODO: the CustomTasks.Add is wrong below. It gets called three times, rather than just once for a single input.
             //       But I do not understand how to link it to the CUustomTask list above there.
+            // TODO: Make sure this runs before targets (how!?) so that it gets a chance to initalize and send info to
+            //       the legal task list in MsBuildMap.cs.
             nugetView.AddChildRoute(
                 "customtasks".MapTo(NugetPackage.CustomTasks, 
                 new[] { 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,45 @@
 
 ### Building the code
 
+Tools required:
+===============
+
+1. The sysinternal tools (handle in particular) should be part of your path
+
+Building
+========
+
+1. Open solution in Visual Studio 2013
+2. Right click on the solution, select "manage nuget packages", then click on the "download all pacakges". Note that it isn't actually enough to just build. Some packages won't come down.
+2. Build all
+
+Running
+=======
+
+1. cd into the output\Debug\AnyCPU\bin directory in powershell
+2. issue the powershell "import-module .\coapp.psd1"
+
+As a short-cut you can run powershell in the debugger:
+1. In the CoApp.Powershell.Tools property, Debug tag, fill in:
+	- The executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+	- The command line arguments enter: -NoExit -Command "Import-Module .\CoApp.psd1"
+2. Hit "Start" and it should bring up a debugger attached and you can set break points.
+
+Notes: 
+ - Show-CoAppEtcDirectory will not work unless you have installed powershell. I've only seen it necessary to uninstall the real version of CoApp tools if you get an error message about conflicting types during the import-module command.
+ - It is also useful to attach "powershell.exe" as the program to run when with the CoApp.Powershell project so you can just click "debug"
+
+Suggested Workflow:
+===================
+
+0. Fork coApp.Powershell
+1. Build the solution. This will modify a lot of sources that are stored in git
+2. Move all the modified sources to the "excluded" list of files.
+3. Modify and debug your solution, and check those changes into your fork.
+
+Comments
+========
+
 `<coming soon>`
 
 ### Installing the tools 


### PR DESCRIPTION
This patch is the first step to declaring a custom MSBuild task for use in an autopkg file (see issue #95).

Under the nuget node one can write:

```
customtasks {
    task {
        name = AddDebugEnv;
        DLL = ..\ROOTPackageBuilders\ROOTMSBuildTasks\bin\Release\ROOTMSBuildTasks.dll;
    };
};
```

And then one can write:

```
targets {
    AfterBuild {
        .AddDebugEnv {
            EnvVarName = "PYTHIA8Data";
            EnvValue = "$(SolutionDir)\$(Configuration)\Pythia8Data" ;
            UserSettingsPath = "$(ProjectPath).user";
            ConfigPlatform = "$(Configuration)|$(Platform)";
        };
    }
}       
```

While the code works and will produce a working nupkg file with overlays that runs the custom task, there are two known issues with this pull request:
1. The mapping from the property sheets and views into the MSBuild object model is difficult for me to figure out. See line 190 in the patch for PackageScript.cs below. It is wrong, but it "works". If someone can give me some guidance on how that should work, I'll update this.
2. The AddDebugEnv currently generates a warning ("Unknown task"). Given the DLL is known, there is no reason Write-Nuget can't load it and its tasks the way it does for the regular msbuild tasks (see MsBuildMap.cs). Unfortunately, the "targets" view in the input source file gets parsed before the "customtasks" node. Seemingly no matter how I re-order the MapTo's in the PackageScript.cs file or in my input file. If someone can give me a hint there, I'll make the rest of the changes to get it scanning the new DLL files.

Any help addressing those issues would be gratefully accepted! Or, obviously, a change in my approach to implementing this as long as there is some way to accomplish what I'm trying to do here!
